### PR TITLE
refactor: improve update category responses♻️

### DIFF
--- a/src/modules/categories/category.repository.ts
+++ b/src/modules/categories/category.repository.ts
@@ -193,16 +193,11 @@ export async function getCategoryByIdOrNameRepository(
   return category;
 }
 
-export async function updateCategoryByIdAndUserIdRepository(
+export async function updateCategoryByIdRepository(
   categoryId: string,
   categoryPayload: Partial<TInsertCategorySchema>,
-  userId?: string,
 ) {
   const whereCondition = [eq(categoryModel.id, categoryId)];
-
-  if (userId) {
-    whereCondition.push(eq(categoryModel.userId, userId));
-  }
 
   categoryPayload.name = categoryPayload?.name?.toLowerCase();
   categoryPayload.updatedAt = new Date();

--- a/src/modules/categories/category.routes.ts
+++ b/src/modules/categories/category.routes.ts
@@ -192,6 +192,13 @@ export const updateCategoryRoute = createRoute({
       }),
       "You are not allowed to perform this action",
     ),
+    [HTTPStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({
+        success: z.boolean().default(false),
+        message: z.string(),
+      }),
+      "Failed to update category",
+    ),
   },
 });
 


### PR DESCRIPTION
This pull request includes several changes to the category update functionality in the `src/modules/categories` module. The most important changes involve refactoring the update process to simplify the code and improve error handling.

Refactoring and simplification:

* [`src/modules/categories/category.handlers.ts`](diffhunk://#diff-bd3ca6450af4a616dea7a36f3adb314f6841414f29405c343eba171f06e7624cL22-R22): Replaced `updateCategoryByIdAndUserIdRepository` with `updateCategoryByIdRepository` and added checks to ensure the category exists and the user is authorized to update it. Improved error handling for cases where the category is not found or the update fails. [[1]](diffhunk://#diff-bd3ca6450af4a616dea7a36f3adb314f6841414f29405c343eba171f06e7624cL22-R22) [[2]](diffhunk://#diff-bd3ca6450af4a616dea7a36f3adb314f6841414f29405c343eba171f06e7624cL187-R236)

Repository changes:

* [`src/modules/categories/category.repository.ts`](diffhunk://#diff-38017bbc80bda2095fdd80b95f03821b05372c94579b6e5cdcd18bc10c3f9025L196-L206): Removed the `userId` parameter from the `updateCategoryByIdRepository` function and simplified the update logic.

Route updates:

* [`src/modules/categories/category.routes.ts`](diffhunk://#diff-b48ee9db8ff1b6939def2d718ae17fb49c542f480bac2a1a9633e59ee7c20fb1R195-R201): Added a new error response for internal server errors to the `updateCategoryRoute`.