### PR TITLE
feat: implement delete category endpoint✨

### DIFF
--- a/src/modules/categories/category.index.ts
+++ b/src/modules/categories/category.index.ts
@@ -7,5 +7,5 @@ export const categoryRouter = createRouter()
   .openapi(routes.getCategoriesRoute, handlers.getCategories)
   .openapi(routes.createCategoryRoute, handlers.createCategory)
   .openapi(routes.getCategoryRoute, handlers.getCategory)
-  .openapi(routes.updateCategoryRoute, handlers.updateCategory);
-// .openapi(routes.deleteCategoryRoute, handlers.deleteCategory);
+  .openapi(routes.updateCategoryRoute, handlers.updateCategory)
+  .openapi(routes.deleteCategoryRoute, handlers.deleteCategory);

--- a/src/modules/categories/category.repository.ts
+++ b/src/modules/categories/category.repository.ts
@@ -210,3 +210,12 @@ export async function updateCategoryByIdRepository(
 
   return category;
 }
+
+export async function deleteCategoryByIdRepository(categoryId: string) {
+  const [category] = await db
+    .delete(categoryModel)
+    .where(eq(categoryModel.id, categoryId))
+    .returning();
+
+  return category;
+}

--- a/src/modules/categories/category.routes.ts
+++ b/src/modules/categories/category.routes.ts
@@ -205,7 +205,7 @@ export const updateCategoryRoute = createRoute({
 export const deleteCategoryRoute = createRoute({
   tags,
   method: "delete",
-  path: "/categories/:id",
+  path: "/categories/:categoryId",
   middleware: [
     authMiddleware(),
     requireAuth(),
@@ -213,7 +213,7 @@ export const deleteCategoryRoute = createRoute({
   ] as const,
   request: {
     params: z.object({
-      id: z.string(),
+      categoryId: z.string(),
     }),
   },
   responses: {
@@ -245,6 +245,13 @@ export const deleteCategoryRoute = createRoute({
         message: z.string(),
       }),
       "You are not allowed to perform this action",
+    ),
+    [HTTPStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({
+        success: z.boolean().default(false),
+        message: z.string(),
+      }),
+      "Failed to delete category",
     ),
   },
 });


### PR DESCRIPTION
This pull request introduces a new feature to allow the deletion of categories in the categories module. The most important changes include adding a new route and handler for deleting categories, updating the repository to support category deletion, and modifying the route parameters for consistency.

New feature for deleting categories:

* [`src/modules/categories/category.handlers.ts`](diffhunk://#diff-bd3ca6450af4a616dea7a36f3adb314f6841414f29405c343eba171f06e7624cR10-R18): Added `TDeleteCategoryRoute` type and implemented the `deleteCategory` handler to handle category deletion requests. [[1]](diffhunk://#diff-bd3ca6450af4a616dea7a36f3adb314f6841414f29405c343eba171f06e7624cR10-R18) [[2]](diffhunk://#diff-bd3ca6450af4a616dea7a36f3adb314f6841414f29405c343eba171f06e7624cR243-R299)

Repository updates:

* [`src/modules/categories/category.repository.ts`](diffhunk://#diff-38017bbc80bda2095fdd80b95f03821b05372c94579b6e5cdcd18bc10c3f9025R213-R221): Added `deleteCategoryByIdRepository` function to handle the deletion of categories from the database.

Route updates:

* [`src/modules/categories/category.routes.ts`](diffhunk://#diff-b48ee9db8ff1b6939def2d718ae17fb49c542f480bac2a1a9633e59ee7c20fb1L208-R216): Added `deleteCategoryRoute` and updated the path parameter from `id` to `categoryId` for consistency. [[1]](diffhunk://#diff-b48ee9db8ff1b6939def2d718ae17fb49c542f480bac2a1a9633e59ee7c20fb1L208-R216) [[2]](diffhunk://#diff-b48ee9db8ff1b6939def2d718ae17fb49c542f480bac2a1a9633e59ee7c20fb1R249-R255)