### PR TITLE
fix: update delete group logging/response to use group name instead of ID

### DIFF
--- a/src/modules/group/group.handler.ts
+++ b/src/modules/group/group.handler.ts
@@ -100,12 +100,12 @@ export const deleteGroup: AppRouteHandler<TDeleteGroupRoute> = async (c) => {
       actorName: user.fullName || "",
     },
   });
-  logger.debug(`Group with ${deletedGroup.id} deleted successfully`);
+  logger.debug(`Group ${deletedGroup.name} deleted successfully`);
 
   return c.json(
     {
       success: true,
-      message: `Group with ${deletedGroup.id} deleted successfully`,
+      message: `Group ${deletedGroup.name} deleted successfully`,
     },
     HTTPStatusCodes.OK,
   );


### PR DESCRIPTION
This pull request includes a small change to the `deleteGroup` function in the `group.handler.ts` file. The change modifies the log message and the response message to use the group's name instead of its ID.

* [`src/modules/group/group.handler.ts`](diffhunk://#diff-7dde1ee0788fcde31f3b2561c7b7cb581c1555559ac697f19406072f6535f8f1L103-R108): Changed the log and response messages to use `deletedGroup.name` instead of `deletedGroup.id` for better readability.…f ID