### PR TITLE
feat: add unprocessable entity error to openapi✨

### DIFF
--- a/src/common/schema/create-error.schema.ts
+++ b/src/common/schema/create-error.schema.ts
@@ -1,0 +1,30 @@
+import { z } from "@hono/zod-openapi";
+
+import type { ZodSchema } from "../lib/types";
+
+function createErrorSchema<T extends ZodSchema>(schema: T) {
+  const { error } = schema.safeParse(
+    schema._def.typeName === z.ZodFirstPartyTypeKind.ZodArray ? [] : {},
+  );
+  return z.object({
+    success: z.boolean().openapi({
+      example: false,
+    }),
+    error: z
+      .object({
+        issues: z.array(
+          z.object({
+            code: z.string(),
+            path: z.array(z.union([z.string(), z.number()])),
+            message: z.string().optional(),
+          }),
+        ),
+        name: z.string(),
+      })
+      .openapi({
+        example: error,
+      }),
+  });
+}
+
+export default createErrorSchema;

--- a/src/modules/auth/auth.routes.ts
+++ b/src/modules/auth/auth.routes.ts
@@ -6,6 +6,7 @@ import {
   authMiddleware,
   requireAuth,
 } from "@/common/middlewares/auth.middleware";
+import createErrorSchema from "@/common/schema/create-error.schema";
 import * as HTTPStatusCodes from "@/common/utils/http-status-codes.util";
 import { insertUserSchema, selectUserSchema } from "@/db/schemas/user.model";
 
@@ -55,6 +56,14 @@ export const registerRoute = createRoute({
         message: z.string(),
       }),
       "Field already exist(s)",
+    ),
+    [HTTPStatusCodes.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(
+        insertUserSchema.extend({
+          password: z.string().min(8).max(60),
+        }),
+      ),
+      "The validation error(s)",
     ),
     [HTTPStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       z.object({

--- a/src/modules/categories/category.routes.ts
+++ b/src/modules/categories/category.routes.ts
@@ -9,6 +9,7 @@ import {
   checkRoleGuard,
   requireAuth,
 } from "@/common/middlewares/auth.middleware";
+import createErrorSchema from "@/common/schema/create-error.schema";
 import { metadataSchema } from "@/common/schema/metadata.schema";
 import * as HTTPStatusCodes from "@/common/utils/http-status-codes.util";
 import {
@@ -69,6 +70,10 @@ export const createCategoryRoute = createRoute({
         message: z.string(),
       }),
       "Category already exists",
+    ),
+    [HTTPStatusCodes.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertCategorySchema),
+      "The validation error(s)",
     ),
     [HTTPStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       z.object({

--- a/src/modules/group/group.routes.ts
+++ b/src/modules/group/group.routes.ts
@@ -9,6 +9,7 @@ import {
   checkRoleGuard,
   requireAuth,
 } from "@/common/middlewares/auth.middleware";
+import createErrorSchema from "@/common/schema/create-error.schema";
 import * as HTTPStatusCodes from "@/common/utils/http-status-codes.util";
 import { insertGroupSchema, selectGroupSchema } from "@/db/schemas/group.model";
 
@@ -56,6 +57,10 @@ export const createGroupRoute = createRoute({
         message: z.string(),
       }),
       "You are not authorized, please login",
+    ),
+    [HTTPStatusCodes.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertGroupSchema),
+      "The validation error(s)",
     ),
     [HTTPStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       z.object({


### PR DESCRIPTION
This pull request introduces a new utility function `createErrorSchema` to standardize error responses across multiple routes. The changes include the creation of the utility function and its integration into the authentication, category, and group routes.

### Creation of `createErrorSchema` utility function:
* [`src/common/schema/create-error.schema.ts`](diffhunk://#diff-746e503ad9cc474b65d82e8309ff7c58ed770dae66da70a6f5968c1d9a5e5143R1-R30): Added a new utility function `createErrorSchema` to generate standardized error response schemas using `zod`.

### Integration of `createErrorSchema` in various routes:
* [`src/modules/auth/auth.routes.ts`](diffhunk://#diff-653d25cd3b441e992deb9861e96af42e6502a6366309273e72031a6f350e16f4R9): Imported `createErrorSchema` and used it to define the error response schema for the `registerRoute`. [[1]](diffhunk://#diff-653d25cd3b441e992deb9861e96af42e6502a6366309273e72031a6f350e16f4R9) [[2]](diffhunk://#diff-653d25cd3b441e992deb9861e96af42e6502a6366309273e72031a6f350e16f4R60-R67)
* [`src/modules/categories/category.routes.ts`](diffhunk://#diff-b48ee9db8ff1b6939def2d718ae17fb49c542f480bac2a1a9633e59ee7c20fb1R12): Imported `createErrorSchema` and used it to define the error response schema for the `createCategoryRoute`. [[1]](diffhunk://#diff-b48ee9db8ff1b6939def2d718ae17fb49c542f480bac2a1a9633e59ee7c20fb1R12) [[2]](diffhunk://#diff-b48ee9db8ff1b6939def2d718ae17fb49c542f480bac2a1a9633e59ee7c20fb1R74-R77)
* [`src/modules/group/group.routes.ts`](diffhunk://#diff-b2c736f32bb61240b674ee52da27188ff883b581b0698bf9503ece088a7ee42eR12): Imported `createErrorSchema` and used it to define the error response schema for the `createGroupRoute`. [[1]](diffhunk://#diff-b2c736f32bb61240b674ee52da27188ff883b581b0698bf9503ece088a7ee42eR12) [[2]](diffhunk://#diff-b2c736f32bb61240b674ee52da27188ff883b581b0698bf9503ece088a7ee42eR61-R64)