### PR TITLE
feat: add unprocessableEntity error to OpenAPI, add test✨✅

### DIFF
--- a/src/modules/activities/activity.routes.ts
+++ b/src/modules/activities/activity.routes.ts
@@ -6,6 +6,7 @@ import {
   authMiddleware,
   requireAuth,
 } from "@/common/middlewares/auth.middleware";
+import createErrorSchema from "@/common/schema/create-error.schema";
 import { metadataSchema } from "@/common/schema/metadata.schema";
 import * as HTTPStatusCodes from "@/common/utils/http-status-codes.util";
 
@@ -36,13 +37,16 @@ export const getActivitiesRoute = createRoute({
       }),
       "Categories retrieved successfully",
     ),
-
     [HTTPStatusCodes.UNAUTHORIZED]: jsonContent(
       z.object({
         success: z.boolean().default(false),
         message: z.string(),
       }),
       "You are not authorized, please login",
+    ),
+    [HTTPStatusCodes.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(activityQuerySchema),
+      "The validation error(s)",
     ),
   },
 });

--- a/src/modules/activities/activity.test.ts
+++ b/src/modules/activities/activity.test.ts
@@ -98,8 +98,12 @@ describe("Activities List", () => {
     );
 
     expect(response.status).toBe(401);
-    const json = await response.json();
-    expect(json.message).toBe("You are not authorized, please login");
+
+    if (response.status === 401) {
+      const json = await response.json();
+
+      expect(json.message).toBe("You are not authorized, please login");
+    }
   });
 
   it("should return activities with correct metadata structure", async () => {
@@ -167,5 +171,26 @@ describe("Activities List", () => {
       expect(json.metadata.page).toBe(2);
       expect(json.metadata.limit).toBe(5);
     }
+  });
+
+  it("should handle invalid page numbers gracefully", async () => {
+    const response = await activityClient.activities.$get(
+      {
+        query: {
+          page: "-1",
+          limit: "10",
+        },
+      },
+      {
+        headers: {
+          session: sessionToken,
+        },
+      },
+    );
+
+    const json = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(json.success).toBe(false);
   });
 });


### PR DESCRIPTION
This pull request includes several important changes to the `activity.routes.ts` and `activity.test.ts` files in the `src/modules/activities` directory. The changes primarily focus on improving error handling and enhancing test coverage.

Improvements to error handling:

* [`src/modules/activities/activity.routes.ts`](diffhunk://#diff-e58ff7894754353c76e236a47e4096925c4f4164e12f7436f276607fd19d39beR9): Added import for `createErrorSchema` and included a new error response for `HTTPStatusCodes.UNPROCESSABLE_ENTITY` to handle validation errors. [[1]](diffhunk://#diff-e58ff7894754353c76e236a47e4096925c4f4164e12f7436f276607fd19d39beR9) [[2]](diffhunk://#diff-e58ff7894754353c76e236a47e4096925c4f4164e12f7436f276607fd19d39beL39-R50)

Enhancements to test coverage:

* [`src/modules/activities/activity.test.ts`](diffhunk://#diff-ef210f5c15857d7bd3e7cdd0ca7658a8ade61acd62be682679f50ef0bd910a22R101-R106): Added a conditional check to verify the response message when the status is 401 (unauthorized).
* [`src/modules/activities/activity.test.ts`](diffhunk://#diff-ef210f5c15857d7bd3e7cdd0ca7658a8ade61acd62be682679f50ef0bd910a22R175-R195): Introduced a new test case to handle invalid page numbers gracefully, ensuring the response status is 422 (unprocessable entity) and the success flag is false.