### PR TITLE
fix(docker): .emv filename in dev docker compose🐳

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "8998:8998"
     env_file:
-      - .env.development
+      - .env
     environment:
       - DATABASE_URL=postgresql://root:root@db:5432/finance-management-api-dev
     depends_on:


### PR DESCRIPTION
This pull request includes a change to the `docker-compose.dev.yml` file to update the environment configuration.

Configuration update:

* [`docker-compose.dev.yml`](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1L12-R12): Changed the `env_file` reference from `.env.development` to `.env` to streamline environment variable management.