### PR TITLE
feat: add test label for .(test|spec).ts files✨

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,3 +3,7 @@ documentation:
 
 workflows:
   - ".github/workflows/**/*"
+
+test:
+  - "**/*.test.ts"
+  - "**/*.spec.ts"


### PR DESCRIPTION
This pull request includes a small change to the `.github/labeler.yml` file. The change adds a new `test` label to categorize files with `.test.ts` and `.spec.ts` extensions.

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR6-R9): Added a new `test` label to categorize files with `.test.ts` and `.spec.ts` extensions.