### PR TITLE
docs: include test setup instructions in README📝

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,53 @@
+# API Documentation
 documentation:
   - "**/*.md"
+  - src/common/lib/configure-open-api.lib.ts
 
+# Database related changes
+database:
+  - "src/db/**/*"
+  - drizzle.config.ts
+  - "migrations/**/*"
+
+config:
+  - "*.config.*"
+  - ".env*"
+  - tsconfig.json
+  - ".eslintrc*"
+  - ".prettierrc*"
+  - .dockerignore
+  - .gitignore
+  - ".vscode/**/*"
+
+# Docker related changes
+docker:
+  - Dockerfile
+  - "docker-compose*.yml"
+  - .dockerignore
+
+# GitHub Actions
 workflows:
-  - ".github/workflows/**/*"
+  - ".github/**/*"
 
-test:
+# Testing
+tests:
   - "**/*.test.ts"
   - "**/*.spec.ts"
+  - src/db/scripts/clear-db.script.ts
+
+# Dependencies
+dependencies:
+  - package.json
+  - bun.lockb
+
+# Development tooling
+tooling:
+  - Makefile
+  - ".husky/**/*"
+  - ".vscode/**/*"
+  - .editorconfig
+
+# Security related changes
+security:
+  - src/common/utils/crypto.lib.ts
+  - "src/modules/auth/**/*"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ If you encounter any issues:
    make logs
    ```
 
+### Test Environment Setup
+
+1. Create a test environment file:
+
+   ```bash
+   cp .env.example .env.test
+   ```
+
+2. Update the `.env.test` file with the following configurations:
+
+   ```env
+   LOG_LEVEL=silent
+   DATABASE_URL=postgres://root:root@localhost:5432/finance-management-api-test
+   ```
+
+3. When running tests, the application will automatically use `.env.test` configuration:
+   ```bash
+   bun run test
+   ```
+
+Note: The test database will be automatically created and migrated when running tests.
+
 ### Production Deployment
 
 For production deployment:


### PR DESCRIPTION
This pull request includes several updates to the project configuration, documentation, and test setup. The most important changes include additions to the GitHub labeler configuration and updates to the README file for setting up a test environment.

Configuration and tooling updates:

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR1-R53): Added new labels for API documentation, database-related changes, configuration files, Docker-related changes, GitHub Actions, testing, dependencies, development tooling, and security-related changes.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R130-R151): Added a new section for setting up the test environment, including instructions for creating and configuring a test environment file and running tests.