### PR TITLE
feat: add script to reset db✨

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "db:seed": "NODE_ENV=development bun run src/db/scripts/seed-db.script.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:reset": "bun run src/db/scripts/reset-db.script.ts",
     "deps:update": "npx npm-check-updates --interactive --format group",
     "prepare": "husky || true",
     "check-types": "tsc --noEmit",

--- a/src/db/scripts/reset-db.script.ts
+++ b/src/db/scripts/reset-db.script.ts
@@ -13,9 +13,9 @@ async function main() {
   }
 
   try {
-    console.log("Resetting the database");
+    console.log(`Resetting the database in ${env.NODE_ENV} environment`);
     await reset(db, schema);
-    console.log("Database reset successfully....");
+    console.log(`Database reset successfully in ${env.NODE_ENV} environment`);
     process.exit(0);
   } catch (error) {
     console.log("Something went wrong in resetting the database", error);

--- a/src/db/scripts/reset-db.script.ts
+++ b/src/db/scripts/reset-db.script.ts
@@ -19,6 +19,7 @@ async function main() {
     process.exit(0);
   } catch (error) {
     console.log("Error resetting the database: ", error);
+    process.exit(1);
   }
 }
 

--- a/src/db/scripts/reset-db.script.ts
+++ b/src/db/scripts/reset-db.script.ts
@@ -1,0 +1,25 @@
+/* eslint-disable no-console */
+import { reset } from "drizzle-seed";
+
+import env from "@/env";
+
+import { db } from "../adapter";
+import * as schema from "../schemas";
+
+async function main() {
+  if (env.NODE_ENV === "production") {
+    console.log("Cannot reset the database in production environment");
+    throw new Error("Cannot reset the database in production environment");
+  }
+
+  try {
+    console.log("Resetting the database");
+    await reset(db, schema);
+    console.log("Database reset successfully....");
+    process.exit(0);
+  } catch (error) {
+    console.log("Something went wrong in resetting the database", error);
+  }
+}
+
+await main();

--- a/src/db/scripts/reset-db.script.ts
+++ b/src/db/scripts/reset-db.script.ts
@@ -18,7 +18,7 @@ async function main() {
     console.log(`Database reset successfully in ${env.NODE_ENV} environment`);
     process.exit(0);
   } catch (error) {
-    console.log("Something went wrong in resetting the database", error);
+    console.log(`Error resetting the database: ${error.message}`);
   }
 }
 

--- a/src/db/scripts/reset-db.script.ts
+++ b/src/db/scripts/reset-db.script.ts
@@ -18,7 +18,7 @@ async function main() {
     console.log(`Database reset successfully in ${env.NODE_ENV} environment`);
     process.exit(0);
   } catch (error) {
-    console.log(`Error resetting the database: ${error.message}`);
+    console.log("Error resetting the database: ", error);
   }
 }
 


### PR DESCRIPTION
This pull request includes changes to add a new database reset script and the corresponding command in the `package.json` file. The most important changes include adding a new script file for resetting the database and updating the `package.json` to include a command for this script.

Database reset functionality:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R25): Added a new script command `db:reset` to run the database reset script.
* [`src/db/scripts/reset-db.script.ts`](diffhunk://#diff-5a5b92df504312c5df79eb03c9e5ce9428af74b0993a318769fafbea083adf53R1-R25): Added a new script to reset the database, including checks to prevent resetting in a production environment and logging for success or errors.