### PR TITLE
hotfix: debug api running in docker🚑️

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,8 @@ services:
       - /usr/src/app/node_modules
     ports:
       - "8998:8998"
+      - "8999:8999"
+      - "6499:6499"
     env_file:
       - .env
     environment:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "bun build ./src/index.ts --outdir ./dist --target bun",
-    "dev": "bun run --watch --inspect src/index.ts",
+    "dev": "bun run --watch --inspect=0.0.0.0:6499 src/index.ts",
     "lint": "eslint .",
     "lint:fix": "bun lint --fix",
     "start": "bun src/index.ts",


### PR DESCRIPTION
This pull request includes a fix to debugging API which is running inside docker.

When you run docker development, it will also start debugger and give you a URL back, in that URL you will see 0.0.0.0, just replace that with 127.0.0.1 and paste it in your browser, a debugger UI will open where you can debug your API.

Ex: 

```bash
Listening:
api-1  |   ws://0.0.0.0:6499/yn62oycjc8
api-1  | Inspect in browser:
api-1  |   https://debug.bun.sh/#0.0.0.0:6499/yn62oycjc8
```

Now copy the URL `https://debug.bun.sh/#0.0.0.0:6499/yn62oycjc8` and change `0.0.0.0` to `127.0.0.1` and paste it in your browser, you should see a UI as shown below

![CleanShot 2024-12-08 at 10 46 43](https://github.com/user-attachments/assets/ecc4c3b4-b0e2-4487-a623-6e019e7fb67c)

To read more about debugging in bunjs read the [official documentation](https://bun.sh/docs/runtime/debugger)