### PR TITLE
fix: only lint the files that are staged and not all🐛

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 bun check-types
-bun lint:fix
+bunx lint-staged
 bun run test


### PR DESCRIPTION
This pull request includes a small but important change to the `.husky/pre-commit` file. The change updates the linting command to use `lint-staged` instead of `lint:fix`.

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL2-R2): Updated the linting command to use `bunx lint-staged` instead of `bun lint:fix`.