### PR TITLE
fix: use GITHUB_TOKEN instead of GH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,5 @@ jobs:
         run: npm i -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/commit-analyzer conventional-changelog-conventionalcommits
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release --debug;


### PR DESCRIPTION
### PR Summary
*****************
Updated release actions env variable to default `GITHUB_TOKEN`.