### PR TITLE
build(docker): spin up a test DB when running docker copmose dev file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,6 +39,13 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    command: >
+      bash -c "
+        docker-entrypoint.sh postgres &
+        sleep 10
+        psql -U root -d postgres -c \"CREATE DATABASE \\\"finance-management-api-test\\\"\"
+        wait
+      "
 
 networks:
   finance-management-api-dev-network:


### PR DESCRIPTION
This MR introduces a command in dev docker compose which will automatically spin up a test db which will be used to run the test cases

fix #115