### PR TITLE
fix(settlement validations): add id validation

### DIFF
--- a/src/db/schemas/settlement.model.ts
+++ b/src/db/schemas/settlement.model.ts
@@ -1,10 +1,4 @@
-import {
-  pgEnum,
-  pgTable,
-  real,
-  timestamp,
-  varchar,
-} from "drizzle-orm/pg-core";
+import { pgEnum, pgTable, real, timestamp, varchar } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import type { z } from "zod";
 
@@ -16,10 +10,8 @@ const settlementModel = pgTable("settlement", {
   id: varchar({ length: 60 })
     .$defaultFn(() => Bun.randomUUIDv7())
     .primaryKey(),
-  senderId: varchar({ length: 60 })
-    .notNull(),
-  receiverId: varchar({ length: 60 })
-    .notNull(),
+  senderId: varchar({ length: 60 }).notNull(),
+  receiverId: varchar({ length: 60 }).notNull(),
   groupId: varchar({ length: 60 }),
   amount: real().notNull(),
   createdAt: timestamp().notNull().defaultNow(),
@@ -30,13 +22,20 @@ const settlementModel = pgTable("settlement", {
 export const selectSettlementSchema = createSelectSchema(settlementModel, {
   id: schema => schema.id.describe("Unique identifier for the settlement"),
   senderId: schema =>
-    schema.senderId.describe("Reference to the user who is payer"),
+    schema.senderId
+      .min(60)
+      .max(60)
+      .describe("Reference to the user who is payer"),
   receiverId: schema =>
-    schema.receiverId.describe("Reference to the user who is ower "),
+    schema.receiverId
+      .min(60)
+      .max(60)
+      .describe("Reference to the user who is ower "),
   groupId: schema =>
-    schema.groupId.describe(
-      "Reference to the group the settlement belongs to",
-    ),
+    schema.groupId
+      .min(60)
+      .max(60)
+      .describe("Reference to the group the settlement belongs to"),
   amount: schema => schema.amount.describe("Amount of the settlement"),
   createdAt: schema =>
     schema.createdAt.describe("Timestamp when the settlement was created"),
@@ -47,13 +46,20 @@ export const selectSettlementSchema = createSelectSchema(settlementModel, {
 export const insertSettlementSchema = createInsertSchema(settlementModel, {
   id: schema => schema.id.describe("Unique identifier for the settlement"),
   senderId: schema =>
-    schema.senderId.describe("Reference to the user who is payer"),
+    schema.senderId
+      .min(60)
+      .max(60)
+      .describe("Reference to the user who is payer"),
   receiverId: schema =>
-    schema.receiverId.describe("Reference to the user who is ower "),
+    schema.receiverId
+      .min(60)
+      .max(60)
+      .describe("Reference to the user who is ower "),
   groupId: schema =>
-    schema.groupId.describe(
-      "Reference to the group the settlement belongs to",
-    ),
+    schema.groupId
+      .min(60)
+      .max(60)
+      .describe("Reference to the group the settlement belongs to"),
   amount: schema => schema.amount.describe("Amount of the settlement"),
   createdAt: schema =>
     schema.createdAt.describe("Timestamp when the settlement was created"),


### PR DESCRIPTION
This pull request includes changes to the `settlement.model.ts` file to clean up imports, improve code readability, and enhance schema validation for the `settlement` model. The most important changes include consolidating imports, reformatting model definitions, and adding validation constraints to schema fields.

Code cleanup and readability improvements:

* Consolidated imports in `src/db/schemas/settlement.model.ts` to a single line.
* Reformatted `senderId` and `receiverId` definitions in the `settlementModel` to a single line each.

Schema validation enhancements:

* Added `.min(60)` and `.max(60)` validation constraints to `senderId`, `receiverId`, and `groupId` fields in the `selectSettlementSchema`.
* Added `.min(60)` and `.max(60)` validation constraints to `senderId`, `receiverId`, and `groupId` fields in the `insertSettlementSchema`.